### PR TITLE
<fix>:issue29の修正対応

### DIFF
--- a/postgres/init/01_init.sql
+++ b/postgres/init/01_init.sql
@@ -12,4 +12,4 @@ CREATE TABLE userInfo (
 	latest_access_time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 -- サンプルデータの登録
-INSERT INTO userInfo (userId, userName, userPassword) VALUES('sampleUserId1', 'sample UserName1', 'abcdef');
+INSERT INTO userInfo (userId, userName, userPassword) VALUES('sampleUserId1', 'sample UserName1', 'abcdefgh');

--- a/src/main/java/com/example/sample_back/controller/user/LoginController.java
+++ b/src/main/java/com/example/sample_back/controller/user/LoginController.java
@@ -5,6 +5,7 @@ import com.example.sample_back.service.login.UserEntity;
 import com.example.sampleback.controller.LoginApi;
 import com.example.sampleback.model.RequestLogin;
 import com.example.sampleback.model.SuccessLogin;
+import com.example.sampleback.model.SuccessLoginUser;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
@@ -25,12 +26,11 @@ public class LoginController implements LoginApi {
      * or Internal Server Error (status code 500)
      */
     @Override
-    public ResponseEntity<SuccessLogin> loginPost(RequestLogin requestLogin) {
-        UserEntity entity = service.find(requestLogin);
-        SuccessLogin successLogin = new SuccessLogin();
-        successLogin.setUserId(entity.getUserId());
-        successLogin.setUserName(entity.getUserName());
-        successLogin.setLoginCheck(entity.getLoginCheck());
-        return ResponseEntity.ok(successLogin);
+    public ResponseEntity<SuccessLoginUser> loginPost(RequestLogin requestLogin) {
+        SuccessLoginUser entity = service.find(requestLogin);
+        return ResponseEntity.ok(entity);
     }
+
+
+
 }

--- a/src/main/java/com/example/sample_back/controller/user/LoginController.java
+++ b/src/main/java/com/example/sample_back/controller/user/LoginController.java
@@ -26,8 +26,8 @@ public class LoginController implements LoginApi {
      */
     @Override
     public ResponseEntity<SuccessLoginUser> loginPost(RequestLogin requestLogin) {
-        SuccessLoginUser entity = service.find(requestLogin);
-        return ResponseEntity.ok(entity);
+        SuccessLoginUser response = service.find(requestLogin);
+        return ResponseEntity.ok(response);
     }
 
 

--- a/src/main/java/com/example/sample_back/controller/user/LoginController.java
+++ b/src/main/java/com/example/sample_back/controller/user/LoginController.java
@@ -30,6 +30,4 @@ public class LoginController implements LoginApi {
         return ResponseEntity.ok(response);
     }
 
-
-
 }

--- a/src/main/java/com/example/sample_back/controller/user/LoginController.java
+++ b/src/main/java/com/example/sample_back/controller/user/LoginController.java
@@ -4,7 +4,6 @@ import com.example.sample_back.service.login.LoginService;
 import com.example.sample_back.service.login.UserEntity;
 import com.example.sampleback.controller.LoginApi;
 import com.example.sampleback.model.RequestLogin;
-import com.example.sampleback.model.SuccessLogin;
 import com.example.sampleback.model.SuccessLoginUser;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/example/sample_back/exception/UnauthorizedException.java
+++ b/src/main/java/com/example/sample_back/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.example.sample_back.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/sample_back/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/sample_back/handler/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.example.sample_back.handler;
 
 import com.example.sample_back.exception.FailureRegistUserException;
+import com.example.sample_back.exception.UnauthorizedException;
 import com.example.sampleback.model.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -39,6 +40,23 @@ public class GlobalExceptionHandler {
         errorResponse.setData(errorData);
         log.error("Illegal argument error", ex);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthorizedException(UnauthorizedException ex) {
+        ErrorResponse errorResponse = new ErrorResponse();
+        ErrorResponseInfo erorrInfo = new ErrorResponseInfo();
+        erorrInfo.setCode("401");
+        erorrInfo.setMessage("fail");
+        ErrorData errorData = new ErrorData();
+        errorData.setUserId("");
+        errorData.setUserName("");
+        errorData.setLoginCheck(false);
+        errorData.setMessage(ex.getMessage());
+        errorResponse.setResponseInfo(erorrInfo);
+        errorResponse.setData(errorData);
+        log.error("Illegal argument error", ex);
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
     }
 
     @ExceptionHandler(FailureRegistUserException.class)

--- a/src/main/java/com/example/sample_back/service/login/LoginService.java
+++ b/src/main/java/com/example/sample_back/service/login/LoginService.java
@@ -4,6 +4,9 @@ import ch.qos.logback.core.util.StringUtil;
 import com.example.sample_back.repository.login.UserRecord;
 import com.example.sample_back.repository.login.UserRepository;
 import com.example.sampleback.model.RequestLogin;
+import com.example.sampleback.model.SuccessLogin;
+import com.example.sampleback.model.SuccessLoginUser;
+import com.example.sampleback.model.SuccessResponseInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.ibatis.exceptions.TooManyResultsException;
@@ -16,7 +19,13 @@ public class LoginService {
 
     private final UserRepository repository;
 
-    public UserEntity find(RequestLogin request) {
+    public SuccessLoginUser find(RequestLogin request) {
+        // レスポンスフォーマット
+        SuccessLoginUser successLoginUser = new SuccessLoginUser();
+        // レスポンスのresponseInfo部分
+        SuccessResponseInfo successResponseInfo = new SuccessResponseInfo();
+        // レスポンスのdata部分
+        SuccessLogin successLogin = new SuccessLogin();
         try {
             boolean loginCheck = false;
             String userId = "";
@@ -27,7 +36,17 @@ public class LoginService {
                 userName = resSelect.getUserName().trim();
                 loginCheck = true;
             }
-            return new UserEntity(userId, userName, loginCheck);
+            String message = loginCheck ? "ログインに成功しました。" : "ログインに失敗しました。ユーザーIDまたはパスワードが正しくありません。";
+            successResponseInfo.setCode("200");
+            successResponseInfo.setMessage("success");
+            successLogin.setUserId(userId);
+            successLogin.setUserName(userName);
+            successLogin.setLoginCheck(loginCheck);
+            successLogin.setMessage(message);
+
+            successLoginUser.setResponseInfo(successResponseInfo);
+            successLoginUser.setData(successLogin);
+            return successLoginUser;
         } catch (TooManyResultsException tooManyResultsException) {
             // ユーザーIDが複数件ヒットした場合は、例外を返す
             log.error("Too many results returned for userId = {}", request.getUserId(), tooManyResultsException);

--- a/src/main/java/com/example/sample_back/service/login/LoginService.java
+++ b/src/main/java/com/example/sample_back/service/login/LoginService.java
@@ -1,6 +1,8 @@
 package com.example.sample_back.service.login;
 
 import ch.qos.logback.core.util.StringUtil;
+import com.example.sample_back.exception.FailureRegistUserException;
+import com.example.sample_back.exception.UnauthorizedException;
 import com.example.sample_back.repository.login.UserRecord;
 import com.example.sample_back.repository.login.UserRepository;
 import com.example.sampleback.model.RequestLogin;
@@ -35,8 +37,11 @@ public class LoginService {
                 userId = resSelect.getUserId().trim();
                 userName = resSelect.getUserName().trim();
                 loginCheck = true;
+            } else {
+                log.error("Unauthorized for userId = {}", request.getUserId());
+                throw new UnauthorizedException("ログインに失敗しました。ユーザーIDまたはパスワードが正しくありません。。");
             }
-            String message = loginCheck ? "ログインに成功しました。" : "ログインに失敗しました。ユーザーIDまたはパスワードが正しくありません。";
+            String message = "ログインに成功しました。";
             successResponseInfo.setCode("200");
             successResponseInfo.setMessage("success");
             successLogin.setUserId(userId);
@@ -51,6 +56,8 @@ public class LoginService {
             // ユーザーIDが複数件ヒットした場合は、例外を返す
             log.error("Too many results returned for userId = {}", request.getUserId(), tooManyResultsException);
             throw new IllegalArgumentException("複数のユーザーが該当しました。");
+        } catch (UnauthorizedException unauthorizedException) {
+            throw unauthorizedException;
         } catch (Exception e) {
             log.error("An exception has occurred", e);
             throw new RuntimeException("サーバー内部でエラーが発生しました。");

--- a/src/main/resources/api-schema.yaml
+++ b/src/main/resources/api-schema.yaml
@@ -150,6 +150,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/errorResponse'
           description: "Client Error"
+        401:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+          description: "Unauthorized"
         500:
           content:
             application/json:
@@ -232,13 +238,13 @@ components:
         password:
           type: string
           format: password
-          minLength: 1
+          minLength: 8
           maxLength: 64
           example: samplePassword1
     # ログイン成功時のレスポンスデータ
     successLogin:
       required:
-        - id
+        - userId
       type: object
       properties:
         userId:

--- a/src/main/resources/api-schema.yaml
+++ b/src/main/resources/api-schema.yaml
@@ -17,19 +17,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/successLogin'
+                $ref: '#/components/schemas/successLoginUser'
           description: "Successfully"
         400:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/failureLogin'
+                $ref: '#/components/schemas/errorResponse'
           description: "Client Error"
         500:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/failureLogin'
+                $ref: '#/components/schemas/errorResponse'
           description: "Internal Server Error"
 
   # itemパス
@@ -148,18 +148,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/errorResponseInfo'
+                $ref: '#/components/schemas/errorResponse'
           description: "Client Error"
         500:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/errorResponseInfo'
+                $ref: '#/components/schemas/errorResponse'
           description: "Internal Server Error"
 
 components:
   schemas:
-    #ユーザー登録のレスポンス（成功）
+    #ユーザー登録成功のレスポンスフォーマット
     successRegistUser:
       allOf:
         - type: object
@@ -169,7 +169,8 @@ components:
             data:
               $ref: "#/components/schemas/responseSuccessRegistUser"
       nullable: true
-    #APIレスポンス（エラー）
+    #APIレスポンスフォーマット（エラー）
+    #すべてのエンドポイントの共通レスポンスフォーマット
     errorResponse:
       allOf:
         - type: object
@@ -178,6 +179,18 @@ components:
               $ref: "#/components/schemas/errorResponseInfo"
             data:
               $ref: "#/components/schemas/errorData"
+
+    #ログイン成功のレスポンスフォーマット
+    successLoginUser:
+      allOf:
+        - type: object
+          properties:
+            responseInfo:
+              $ref: "#/components/schemas/successResponseInfo"
+            data:
+              $ref: "#/components/schemas/successLogin"
+      nullable: true
+
     #レスポンスステータスコード（200）
     successResponseInfo:
       type: object
@@ -222,7 +235,7 @@ components:
           minLength: 1
           maxLength: 64
           example: samplePassword1
-    # ログイン成功
+    # ログイン成功時のレスポンスデータ
     successLogin:
       required:
         - id
@@ -237,6 +250,9 @@ components:
         loginCheck:
           type: boolean
           example: true
+        message:
+          type: string
+          example: "ログインに成功しました。"
     # ログイン失敗
     failureLogin:
       required:

--- a/src/main/resources/mappers/RegistUserRepository.xml
+++ b/src/main/resources/mappers/RegistUserRepository.xml
@@ -8,10 +8,7 @@
         INSERT INTO userInfo (userid, username, userpassword) VALUES(#{userId}, #{userName}, #{password})
     </insert>
 
-    <select id="isRegistedUser" resultType="com.example.sample_back.repository.registUser.RegistUserRepository">
-        SELECT
-        count(*)
-        FROM userinfo
-        WHERE userId = #{userId}
+    <select id="isRegistedUser" resultType="int">
+        SELECT COUNT(*) FROM userinfo WHERE userid = #{userId}
     </select>
 </mapper>

--- a/src/test/java/com/example/sample_back/controller/user/LoginControllerTest.java
+++ b/src/test/java/com/example/sample_back/controller/user/LoginControllerTest.java
@@ -1,7 +1,6 @@
 package com.example.sample_back.controller.user;
 
 import com.example.sample_back.service.login.LoginService;
-import com.example.sample_back.service.login.UserEntity;
 import com.example.sampleback.model.SuccessLogin;
 import com.example.sampleback.model.SuccessLoginUser;
 import com.example.sampleback.model.SuccessResponseInfo;

--- a/src/test/java/com/example/sample_back/controller/user/LoginControllerTest.java
+++ b/src/test/java/com/example/sample_back/controller/user/LoginControllerTest.java
@@ -2,6 +2,9 @@ package com.example.sample_back.controller.user;
 
 import com.example.sample_back.service.login.LoginService;
 import com.example.sample_back.service.login.UserEntity;
+import com.example.sampleback.model.SuccessLogin;
+import com.example.sampleback.model.SuccessLoginUser;
+import com.example.sampleback.model.SuccessResponseInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -41,11 +44,21 @@ class LoginControllerTest {
         @DisplayName("正しいuserIdとpasswordでログイン成功（200 OK）")
         void loginSuccess_withValidCredentials() throws Exception {
             // Given
-            UserEntity userEntity = new UserEntity("testUser", "テストユーザー", true);
-            when(loginService.find(any())).thenReturn(userEntity);
+            SuccessLoginUser successLoginUser = new SuccessLoginUser();
+            SuccessResponseInfo successResponseInfo = new SuccessResponseInfo();
+            SuccessLogin successLogin = new SuccessLogin();
+            successResponseInfo.setCode("200");
+            successResponseInfo.setMessage("success");
+            successLogin.setUserId("successUserId");
+            successLogin.setUserName("テストユーザー");
+            successLogin.setLoginCheck(true);
+            successLogin.setMessage("ログインに成功しました。");
+            successLoginUser.setResponseInfo(successResponseInfo);
+            successLoginUser.setData(successLogin);
+            when(loginService.find(any())).thenReturn(successLoginUser);
 
             Map<String, String> request = new HashMap<>();
-            request.put("userId", "testUser");
+            request.put("userId", "successUserId");
             request.put("password", "testPassword");
 
             // When & Then
@@ -53,9 +66,12 @@ class LoginControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.userId").value("testUser"))
-                    .andExpect(jsonPath("$.userName").value("テストユーザー"))
-                    .andExpect(jsonPath("$.loginCheck").value(true));
+                    .andExpect(jsonPath("$.responseInfo.code").value("200"))
+                    .andExpect(jsonPath("$.responseInfo.message").value("success"))
+                    .andExpect(jsonPath("$.data.userId").value("successUserId"))
+                    .andExpect(jsonPath("$.data.userName").value("テストユーザー"))
+                    .andExpect(jsonPath("$.data.loginCheck").value(true))
+                    .andExpect(jsonPath("$.data.message").value("ログインに成功しました。"));
         }
     }
 
@@ -66,9 +82,20 @@ class LoginControllerTest {
         @Test
         @DisplayName("存在しないユーザーでのログイン失敗")
         void loginFailure_withNonExistentUser() throws Exception {
+
             // Given
-            UserEntity userEntity = new UserEntity("", "", false);
-            when(loginService.find(any())).thenReturn(userEntity);
+            SuccessLoginUser successLoginUser = new SuccessLoginUser();
+            SuccessResponseInfo successResponseInfo = new SuccessResponseInfo();
+            SuccessLogin successLogin = new SuccessLogin();
+            successResponseInfo.setCode("200");
+            successResponseInfo.setMessage("success");
+            successLogin.setUserId("");
+            successLogin.setUserName("");
+            successLogin.setLoginCheck(false);
+            successLogin.setMessage("ログインに失敗しました。ユーザーIDまたはパスワードが正しくありません。");
+            successLoginUser.setResponseInfo(successResponseInfo);
+            successLoginUser.setData(successLogin);
+            when(loginService.find(any())).thenReturn(successLoginUser);
 
             Map<String, String> request = new HashMap<>();
             request.put("userId", "nonExistentUser");
@@ -79,30 +106,13 @@ class LoginControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.userId").value(""))
-                    .andExpect(jsonPath("$.userName").value(""))
-                    .andExpect(jsonPath("$.loginCheck").value(false));
-        }
-
-        @Test
-        @DisplayName("パスワード誤りでのログイン失敗")
-        void loginFailure_withWrongPassword() throws Exception {
-            // Given
-            UserEntity userEntity = new UserEntity("", "", false);
-            when(loginService.find(any())).thenReturn(userEntity);
-
-            Map<String, String> request = new HashMap<>();
-            request.put("userId", "testUser");
-            request.put("password", "wrongPassword");
-
-            // When & Then
-            mockMvc.perform(post("/login")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.userId").value(""))
-                    .andExpect(jsonPath("$.userName").value(""))
-                    .andExpect(jsonPath("$.loginCheck").value(false));
+                    .andExpect(jsonPath("$.responseInfo.code").value("200"))
+                    .andExpect(jsonPath("$.responseInfo.message").value("success"))
+                    .andExpect(jsonPath("$.data.userId").value(""))
+                    .andExpect(jsonPath("$.data.userName").value(""))
+                    .andExpect(jsonPath("$.data.loginCheck").value(false))
+                    .andExpect(jsonPath("$.data.message")
+                            .value("ログインに失敗しました。ユーザーIDまたはパスワードが正しくありません。"));
         }
 
         @Test

--- a/src/test/java/com/example/sample_back/repository/registUser/RegistUserRepositoryTest.java
+++ b/src/test/java/com/example/sample_back/repository/registUser/RegistUserRepositoryTest.java
@@ -41,4 +41,18 @@ public class RegistUserRepositoryTest {
                 requestRegistUser.getUserName(), requestRegistUser.getPassword()))
                 .isInstanceOf(DuplicateKeyException.class);
     }
+
+    @Test
+    @DisplayName("ユーザー確認チェック")
+    void isRegistedUser() {
+        // Given userInfoテーブル、データはschema.sql、data.sqlで定義済
+
+        // When
+        Integer existUserId = registUserRepository.isRegistedUser("ExistsByUserId1");
+        Integer notExistUserId = registUserRepository.isRegistedUser("NotExistsByUserId");
+
+        // Then
+        assertThat(existUserId).isEqualTo(1);
+        assertThat(notExistUserId).isEqualTo(0);
+    }
 }

--- a/src/test/java/com/example/sample_back/service/login/LoginServiceTest.java
+++ b/src/test/java/com/example/sample_back/service/login/LoginServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.sample_back.service.login;
 
+import com.example.sample_back.exception.UnauthorizedException;
 import com.example.sample_back.repository.login.UserRecord;
 import com.example.sample_back.repository.login.UserRepository;
 import com.example.sampleback.model.RequestLogin;
@@ -52,25 +53,15 @@ class LoginServiceTest {
     }
 
     @Test
-    @DisplayName("ユーザーが見つからない場合、空のUserEntityを返す")
+    @DisplayName("ユーザー不正の場合、401ステータスコードと空のUserEntityを返す")
     void find_whenUserNotFound_returnsEmptyUserEntity() {
         RequestLogin request = new RequestLogin("nope", "nopass");
 
-        when(repository.selectUser("nope", "nopass")).thenReturn(userRecord);
-        when(userRecord.getUserId()).thenReturn("");
+        when(repository.selectUser("nope", "nopass"))
+                .thenThrow(new UnauthorizedException("ログインに失敗しました。ユーザーIDまたはパスワードが正しくありません。"));
 
-        SuccessLoginUser result = loginService.find(request);
-
-        assertNotNull(result.getResponseInfo());
-        assertNotNull(result.getData());
-        assertThat(result.getResponseInfo().getCode()).isEqualTo("200");
-        assertThat(result.getResponseInfo().getMessage()).isEqualTo("success");
-        assertNotNull(result.getData().getUserId());
-        assertThat(result.getData().getUserId().isEmpty()).isTrue();
-        assertNotNull(result.getData().getUserName());
-        assertThat(result.getData().getUserName().isEmpty()).isTrue();
-        assertThat(result.getData().getLoginCheck()).isFalse();
-        assertThat(result.getData().getMessage()).isEqualTo("ログインに失敗しました。ユーザーIDまたはパスワードが正しくありません。");
+        UnauthorizedException ex = assertThrows(UnauthorizedException.class, () -> loginService.find(request));
+        assertThat(ex.getMessage()).contains("ログインに失敗しました。ユーザーIDまたはパスワードが正しくありません。");
 
         verify(repository, times(1)).selectUser("nope", "nopass");
     }

--- a/src/test/java/com/example/sample_back/service/login/LoginServiceTest.java
+++ b/src/test/java/com/example/sample_back/service/login/LoginServiceTest.java
@@ -3,6 +3,7 @@ package com.example.sample_back.service.login;
 import com.example.sample_back.repository.login.UserRecord;
 import com.example.sample_back.repository.login.UserRepository;
 import com.example.sampleback.model.RequestLogin;
+import com.example.sampleback.model.SuccessLoginUser;
 import org.apache.ibatis.exceptions.TooManyResultsException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,23 +29,6 @@ class LoginServiceTest {
     private LoginService loginService;
 
     @Test
-    void getFieldValue() {
-        RequestLogin request = new RequestLogin("  uid  ", " pass ");
-
-        when(repository.selectUser("  uid  ", " pass ")).thenReturn(userRecord);
-        when(userRecord.getUserId()).thenReturn(" uid ");
-        when(userRecord.getUserName()).thenReturn(" name ");
-
-        UserEntity result = loginService.find(request);
-
-        assertThat(result.getUserId()).isEqualTo("uid");
-        assertThat(result.getUserName()).isEqualTo("name");
-        assertThat(result.getLoginCheck()).isTrue();
-
-        verify(repository, times(1)).selectUser("  uid  ", " pass ");
-    }
-
-    @Test
     @DisplayName("ユーザーが存在する場合、トリムされたUserEntityを返す")
     void find_whenUserExists_returnsTrimmedUserEntity() {
         RequestLogin request = new RequestLogin("  uid  ", " pass ");
@@ -53,11 +37,16 @@ class LoginServiceTest {
         when(userRecord.getUserId()).thenReturn(" uid ");
         when(userRecord.getUserName()).thenReturn(" name ");
 
-        UserEntity result = loginService.find(request);
+        SuccessLoginUser result = loginService.find(request);
 
-        assertThat(result.getUserId()).isEqualTo("uid");
-        assertThat(result.getUserName()).isEqualTo("name");
-        assertThat(result.getLoginCheck()).isTrue();
+        assertNotNull(result.getResponseInfo());
+        assertNotNull(result.getData());
+        assertThat(result.getResponseInfo().getCode()).isEqualTo("200");
+        assertThat(result.getResponseInfo().getMessage()).isEqualTo("success");
+        assertThat(result.getData().getUserId()).isEqualTo("uid");
+        assertThat(result.getData().getUserName()).isEqualTo("name");
+        assertThat(result.getData().getLoginCheck()).isTrue();
+        assertThat(result.getData().getMessage()).isEqualTo("ログインに成功しました。");
 
         verify(repository, times(1)).selectUser("  uid  ", " pass ");
     }
@@ -68,12 +57,20 @@ class LoginServiceTest {
         RequestLogin request = new RequestLogin("nope", "nopass");
 
         when(repository.selectUser("nope", "nopass")).thenReturn(userRecord);
+        when(userRecord.getUserId()).thenReturn("");
 
-        UserEntity result = loginService.find(request);
+        SuccessLoginUser result = loginService.find(request);
 
-        assertThat(result.getUserId().isEmpty()).isTrue();
-        assertThat(result.getUserName().isEmpty()).isTrue();
-        assertThat(result.getLoginCheck()).isFalse();
+        assertNotNull(result.getResponseInfo());
+        assertNotNull(result.getData());
+        assertThat(result.getResponseInfo().getCode()).isEqualTo("200");
+        assertThat(result.getResponseInfo().getMessage()).isEqualTo("success");
+        assertNotNull(result.getData().getUserId());
+        assertThat(result.getData().getUserId().isEmpty()).isTrue();
+        assertNotNull(result.getData().getUserName());
+        assertThat(result.getData().getUserName().isEmpty()).isTrue();
+        assertThat(result.getData().getLoginCheck()).isFalse();
+        assertThat(result.getData().getMessage()).isEqualTo("ログインに失敗しました。ユーザーIDまたはパスワードが正しくありません。");
 
         verify(repository, times(1)).selectUser("nope", "nopass");
     }
@@ -85,7 +82,8 @@ class LoginServiceTest {
         when(repository.selectUser("dup", "p")).thenThrow(new TooManyResultsException("too many"));
 
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> loginService.find(request));
-        assertTrue(ex.getMessage().contains("複数のユーザー"));
+        assertThat(ex.getMessage()).contains("複数のユーザーが該当しました。");
+
         verify(repository, times(1)).selectUser("dup", "p");
     }
 


### PR DESCRIPTION
ログイン機能のレスポンスを修正し、ログインできるように修正しました。

# 概要
<!-- このPRで何を変更したかを簡潔に -->
- issue対応_ログイン機能のレスポンスを修正し、正しいユーザーでのログインができるように修正しました。

---

## 対応Issue
<!-- 関連Issueを記載（自動クローズ推奨） -->
- Closes #
- Related # https://github.com/Zituryoku-0/sample_back/issues/29

---

## 変更内容
<!-- 主な変更点を箇条書きで -->
- api-schema.yamlにsuccessLoginUserを追加（これがレスポンスのフォーマット）
- LoginServiceでreturnするものを修正

---

## 変更理由・背景
<!-- なぜこの実装にしたのか -->
- レスポンスフォーマットの修正に伴い、ログイン機能も併せて修正する必要があったため

---

## 影響範囲
<!-- 影響が及ぶ可能性のある範囲 -->
- [ ] フロントエンド
- [x] バックエンド
- [ ] DB
- [ ] インフラ
- [ ] 既存機能への影響なし

---

## 動作確認
<!-- 実施した確認内容 -->
- [x] ローカルでの動作確認
- [x] 単体テスト
- [ ] 結合テスト
- [x] 手動テスト

### 確認手順
1.ログイン画面でユーザーID、パスワードを入力する
2.登録ボタンを押す
3.ログインできることを確認する

---

## スクリーンショット / 動作GIF（任意）
特になし

---

## レビュー観点
<!-- レビュアーに見てほしいポイント -->
- ログインできるか
-

---

## チェックリスト（DoD）
- [ ] 要件を満たしている
- [x] コードが可読・保守性を考慮している
- [x] 不要なログ・コメントがない
- [ ] 命名が適切
- [x] 既存テストが壊れていない
- [ ] セキュリティ上の問題がない

---

## 備考
<!-- 補足・懸念点・今後の課題 -->
-
