### PR TITLE
<add>:RegistUserServiceTestの追加

### DIFF
--- a/src/test/java/com/example/sample_back/service/registUser/RegistUserServiceTest.java
+++ b/src/test/java/com/example/sample_back/service/registUser/RegistUserServiceTest.java
@@ -1,0 +1,48 @@
+package com.example.sample_back.service.registUser;
+
+import com.example.sample_back.repository.registUser.RegistUserRepository;
+import com.example.sampleback.model.RequestRegistUser;
+import com.example.sampleback.model.SuccessRegistUser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class RegistUserServiceTest {
+
+    @Mock
+    private RegistUserRepository repository;
+
+    @InjectMocks
+    private RegistUserService service;
+
+    @Test
+    @DisplayName("ユーザー登録に成功する場合のテスト")
+    void successRegistUser() {
+        RequestRegistUser requestRegistUser = new RequestRegistUser("successUserId", "successUserName",
+                "successPassword");
+
+        when(repository.isRegistedUser("successUserId")).thenReturn(0);
+        when(repository.registUser("successUserId", "successUserName", "successPassword"))
+                .thenReturn(1);
+
+        SuccessRegistUser result = service.regist(requestRegistUser);
+
+        assertThat(result.getResponseInfo().getCode()).isEqualTo("201");
+        assertThat(result.getResponseInfo().getMessage()).isEqualTo("success");
+        assertThat(result.getData().getUserId()).isEqualTo("successUserId");
+        assertThat(result.getData().getUserName()).isEqualTo("successUserName");
+        assertThat(result.getData().getLoginCheck()).isTrue();
+        assertThat(result.getData().getMessage()).isEqualTo("ユーザー登録に成功しました。");
+
+        verify(repository, times(1)).isRegistedUser("successUserId");
+        verify(repository, times(1)).registUser("successUserId",
+                "successUserName", "successPassword");
+    }
+}


### PR DESCRIPTION
ひとまず成功パターンの1ケースのみ追加
後で他のパターンも追加する

# 概要
<!-- このPRで何を変更したかを簡潔に -->
ひとまず成功パターンの1ケースのみ追加
後で他のパターンも追加する

---

## 対応Issue
<!-- 関連Issueを記載（自動クローズ推奨） -->
- Closes #
- Related #https://github.com/Zituryoku-0/sample_back/issues/26

---

## 変更内容
<!-- 主な変更点を箇条書きで -->
- RegistUserServiceTest.javaを追加
-

---

## 変更理由・背景
<!-- なぜこの実装にしたのか -->
- RegistUserServiceクラスのテストケースが不足していたため、追加

---

## 影響範囲
<!-- 影響が及ぶ可能性のある範囲 -->
- [ ] フロントエンド
- [ ] バックエンド
- [ ] DB
- [ ] インフラ
- [ ] 既存機能への影響なし

---

## 動作確認
<!-- 実施した確認内容 -->
- [ ] ローカルでの動作確認
- [ ] 単体テスト
- [ ] 結合テスト
- [ ] 手動テスト

### 確認手順
特になし

---

## スクリーンショット / 動作GIF（任意）
<!-- UI変更がある場合は必須 -->
特になし

---

## レビュー観点
<!-- レビュアーに見てほしいポイント -->
- テストケースが成功すること 
-

---

## チェックリスト（DoD）
- [ ] 要件を満たしている
- [ ] コードが可読・保守性を考慮している
- [ ] 不要なログ・コメントがない
- [ ] 命名が適切
- [ ] 既存テストが壊れていない
- [ ] セキュリティ上の問題がない

---

## 備考
<!-- 補足・懸念点・今後の課題 -->
特になし
