### PR TITLE
change:ログイン時にdelete flgも条件に追加するように修正

### DIFF
--- a/postgres/init/01_init.sql
+++ b/postgres/init/01_init.sql
@@ -9,11 +9,14 @@ CREATE TABLE userInfo (
 	userName char(64) NOT NULL,
 	userPassword char(64) NOT NULL,
 	latest_access_time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	delete_flg char(1) NOT NULL DEFAULT '0'
+	delete_flg boolean NOT NULL DEFAULT FALSE,
     PRIMARY KEY (userId)
 );
 -- サンプルデータの登録
 INSERT INTO userInfo (userId, userName, userPassword) VALUES('sampleUserId1', 'sample UserName1', 'abcdefgh');
 INSERT INTO userInfo (userId, userName, userPassword) VALUES('sampleUserId2', 'sample UserName2', 'abcdefgh');
+INSERT INTO userInfo (userId, userName, userPassword) VALUES('NotLoginUserId', 'NotLoginUserName', 'abcdefgh');
 
 UPDATE userInfo SET latest_access_time = '2000-01-01 12:00:00' WHERE userId = 'sampleUserId2';
+-- NotLoginUserの削除フラグを立てる
+UPDATE userInfo SET delete_flg = TRUE WHERE userId = 'NotLoginUserId';

--- a/src/main/resources/mappers/UserRepository.xml
+++ b/src/main/resources/mappers/UserRepository.xml
@@ -11,7 +11,7 @@
         FROM userinfo
         WHERE userId = #{userId}
         AND userPassword = #{password}
-        AND delete_flg = '0'
+        AND delete_flg IS NOT TRUE
     </select>
 
 </mapper>

--- a/src/main/resources/mappers/UserRepository.xml
+++ b/src/main/resources/mappers/UserRepository.xml
@@ -11,7 +11,7 @@
         FROM userinfo
         WHERE userId = #{userId}
         AND userPassword = #{password}
-        AND delete_flg IS NOT TRUE
+        AND delete_flg = FALSE
     </select>
 
 </mapper>

--- a/src/main/resources/mappers/UserRepository.xml
+++ b/src/main/resources/mappers/UserRepository.xml
@@ -11,6 +11,7 @@
         FROM userinfo
         WHERE userId = #{userId}
         AND userPassword = #{password}
+        AND delete_flg = '0'
     </select>
 
 </mapper>

--- a/src/test/java/com/example/sample_back/repository/login/LoginRepositoryTest.java
+++ b/src/test/java/com/example/sample_back/repository/login/LoginRepositoryTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.jdbc.Sql;
 
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/com/example/sample_back/repository/login/LoginRepositoryTest.java
+++ b/src/test/java/com/example/sample_back/repository/login/LoginRepositoryTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -28,6 +29,18 @@ class UserRepositoryTest {
         // Then
         assertThat(userRecord.getUserId().trim()).isEqualTo("sampleUserId1");
         assertThat(userRecord.getUserName().trim()).isEqualTo("sample UserName1");
+    }
+
+    @Test
+    @DisplayName("削除フラグが立っているユーザーの場合、nullを返す")
+    void testSelectUser_deletedUser(){
+        RequestLogin requestLogin = new RequestLogin("NotLoginUserId", "NotLoginUserPassword");
+        UserRecord userRecord = userRepository.selectUser(
+                requestLogin.getUserId(),
+                requestLogin.getPassword()
+        );
+
+        assertThat(userRecord).isNull();
     }
 
     @Test

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -3,4 +3,4 @@ INSERT INTO userInfo (userId, userName, userPassword) VALUES('ExistsByUserId1', 
 INSERT INTO userInfo (userId, userName, userPassword) VALUES('NotLoginUserId', 'NotLoginUserName', 'NotLoginUserPassword');
 
 -- NotLoginUserの削除フラグを立てる
-UPDATE userInfo SET delete_flg = '1' WHERE userId = 'NotLoginUserId';
+UPDATE userInfo SET delete_flg = TRUE WHERE userId = 'NotLoginUserId';

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,2 +1,6 @@
 INSERT INTO userInfo (userId, userName, userPassword) VALUES('sampleUserId1', 'sample UserName1', 'abcdef');
 INSERT INTO userInfo (userId, userName, userPassword) VALUES('ExistsByUserId1', 'ExistsByUserName1', 'ExistsByPassword');
+INSERT INTO userInfo (userId, userName, userPassword) VALUES('NotLoginUserId', 'NotLoginUserName', 'NotLoginUserPassword');
+
+-- NotLoginUserの削除フラグを立てる
+UPDATE userInfo SET delete_flg = '1' WHERE userId = 'NotLoginUserId';

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,7 +1,8 @@
 CREATE TABLE userInfo (
-	userId char(32) NOT NULL PRIMARY KEY ,
+	userId char(32) NOT NULL,
 	userName char(64) NOT NULL,
 	userPassword char(64) NOT NULL,
 	latest_access_time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    delete_flg char(1) NOT NULL DEFAULT '0'
+    delete_flg boolean NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (userId)
 );

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -2,5 +2,6 @@ CREATE TABLE userInfo (
 	userId char(32) NOT NULL PRIMARY KEY ,
 	userName char(64) NOT NULL,
 	userPassword char(64) NOT NULL,
-	latest_access_time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+	latest_access_time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    delete_flg char(1) NOT NULL DEFAULT '0'
 );

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -3,6 +3,6 @@ CREATE TABLE userInfo (
 	userName char(64) NOT NULL,
 	userPassword char(64) NOT NULL,
 	latest_access_time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    delete_flg boolean NOT NULL DEFAULT FALSE,
-    PRIMARY KEY (userId)
+	delete_flg boolean NOT NULL DEFAULT FALSE,
+	PRIMARY KEY (userId)
 );


### PR DESCRIPTION
# 概要
<!-- このPRで何を変更したかを簡潔に -->
- ログイン時にdelete flgも条件に追加するように修正

---

## 対応Issue
<!-- 関連Issueを記載（自動クローズ推奨） -->
- Closes #
- Related #

---

## 変更内容
<!-- 主な変更点を箇条書きで -->
- LoginMapperのSQLにdelete_flgを追加するように修正

---

## 変更理由・背景
<!-- なぜこの実装にしたのか -->
- ユーザー情報削除バッチの実装により、削除フラグをuserinfoテーブルで持つようになり、ログインも削除フラグを考慮する必要があるため

---

## 影響範囲
<!-- 影響が及ぶ可能性のある範囲 -->
- [ ] フロントエンド
- [x] バックエンド
- [x] DB
- [ ] インフラ
- [ ] 既存機能への影響なし

---

## 動作確認
<!-- 実施した確認内容 -->
- [x] ローカルでの動作確認
- [x] 単体テスト
- [ ] 結合テスト
- [ ] 手動テスト

### 確認手順
1.
2.
3.

---

## スクリーンショット / 動作GIF（任意）
<!-- UI変更がある場合は必須 -->
- Before：
- After：

---

## レビュー観点
<!-- レビュアーに見てほしいポイント -->
- 
-

---

## チェックリスト（DoD）
- [ ] 要件を満たしている
- [ ] コードが可読・保守性を考慮している
- [ ] 不要なログ・コメントがない
- [ ] 命名が適切
- [ ] 既存テストが壊れていない
- [ ] セキュリティ上の問題がない

---

## 備考
<!-- 補足・懸念点・今後の課題 -->
-
